### PR TITLE
fix(App): 편의시설 보기 혹은 장애물 보기 버튼 클릭 시 건물 검색 결과 안 보이게 하기

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -241,7 +241,7 @@ const App = () => {
                                 </div>
                             </button>
                         )}
-                        {showFacilitiesMenu && ( // showFacilitiesMenu 상태에 따라 보이게 설정
+                        {showFacilitiesMenu &&( // showFacilitiesMenu 상태에 따라 보이게 설정
                             <div className='showingFacilitiesBtns'>
                                 <button className='showingBtn' onClick={handleToggleFacilitiesMenu}>캠퍼스 내 편의시설 종류별 보기 버튼 가리기</button>
                                 <button className='showingBtn' onClick={() => handleShowReq('atm')}>
@@ -299,7 +299,7 @@ const App = () => {
                             <p>서울시립대학교 어디가 궁금하세요?</p>
                         </div>
                     )}
-                    {keyword != '' && <div className='info-page'>
+                    {keyword != '' && !showFacilitiesMenu && !showObstacleMenu && <div className='info-page'>
                           <Search keyword = {keyword} />
                     </div>}
                 </div>}


### PR DESCRIPTION
## 전 
(맵 밖으로 정보창이 밀려나서 스크롤바가 생김)
![image](https://github.com/je0seo/sinergy-frontend/assets/137382250/0333e93f-eff3-4312-934c-78dc792018b6)

## 후
![image](https://github.com/je0seo/sinergy-frontend/assets/137382250/89022d61-736e-460e-bee0-2cf57aecad5b)
