### PR TITLE
fix(MapC): 건물 영문명 검색 시 대소문자 상관없이 마커 뜨도록 수정

### DIFF
--- a/src/components/MapC.js
+++ b/src/components/MapC.js
@@ -399,7 +399,8 @@ const MapC = ({ pathData, width, height, keyword, setKeyword, ShowReqIdsNtype, /
             }
 
             if (keyword) {
-                let cqlFilter = encodeURIComponent("name like '%"+keyword+"%'" + "or nickname like "+keyword + "or UPPER(eng_name) like UPPER('%"+keyword+"%')"); // Replace 'desiredName' with the name you want to filter by
+                // Replace 'desiredName' with the name you want to filter by
+                let cqlFilter = encodeURIComponent("name like '%"+keyword+"%'" + "or nickname like '"+keyword+"' or eng_name ILIKE '%"+keyword+"%'");
 
                 const poiMarkerLayer = createPoiMarkerLayer(cqlFilter)
                 map.addLayer(poiMarkerLayer)


### PR DESCRIPTION
LIKE: LIKE 연산자는 대소문자를 구분. 즉, 'hello'와 'Hello'를 다른 문자열로 취급
ILIKE: ILIKE 연산자는 대소문자를 구분하지 않음. 'hello'와 'Hello'를 동일한 문자열로 취급

postgreSQL에서도 ILIKE 쓸 수 있다고 함