### PR TITLE
feat(Indoor): 기본 INFO 탭 상황 일 때만 간단하게 뼈대 코드 작성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -385,10 +385,8 @@ const App = () => {
             <div className='ToggleLeftSide'><button className='ToggleLeftSideBtn' onClick={() => {handleToggleLeftSide();}}>{toggleLeftSideFeature}</button></div>
             <div className='main-right-side'>
                 {activeTab === '' && <Map width='100%' height='100vh' keyword={keyword} category ={showReqIdsNtype} />}
-                {/*activeTab === '' && showReqIdsNtype.type && <handleCategoryClick category = {showReqIdsNtype} />*/}
                 {activeTab === '길찾기'
-                && <Map width='100%' height='100vh' keyword={keyword} setKeyword={setKeyword} pathData={pathData}
-                bol = {bol} bump = {bump} showObs = {showObsOnPath}/>}
+                && <Map width='100%' height='100vh' pathData={pathData} bol = {bol} bump = {bump} showObs = {showObsOnPath}/>}
             </div>
         </div>
     );

--- a/src/components/Indoor.js
+++ b/src/components/Indoor.js
@@ -1,0 +1,23 @@
+// 층 정보 DB로부터 가져오기 먼저 (server.js 또는 Gerserver에서 WFS로)
+const getStairs = () => {
+    return totalStairs
+}
+// 모든 층 버튼 만들기
+const createButtons = (totalFloors) => {
+    for (let i=0;i<totalFloors;i++) {
+        // 층 개수만큼 버튼 생성(for문)
+        return (<ButtonUI floor = {i+1}/>)
+    }
+}
+// 해당 층 레이어 표출
+const showTheFloor = (floor) => {
+
+}
+
+const ButtonUI = ({floor, isZoom}) => { // zoom할 시 층 버튼 가시화 <- 이건 MapC에서 줌 되었을 때 어떤 인자를 여기로 보내주든가 해야할 듯
+    return (
+        <div>
+            <button onClick={showTheFloor(floor)}>${floor}층</button>
+        <div>
+    );
+}

--- a/src/components/MapC.js
+++ b/src/components/MapC.js
@@ -1,25 +1,24 @@
 //MapC.js
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import TileLayer from 'ol/layer/Tile';
 import XYZ from 'ol/source/XYZ';
 import Map from 'ol/Map';
 import View from 'ol/View';
 import OSM from 'ol/source/OSM';
 import TileWMS from 'ol/source/TileWMS';
-import { get as getProjection, fromLonLat } from 'ol/proj';
+import { fromLonLat } from 'ol/proj';
 import makeCrsFilter4node from "./utils/filter-for-node.js";
 import {makeCrsFilter} from "./utils/crs-filter.js";
 import VectorSource from "ol/source/Vector";
 import {GeoJSON} from "ol/format";
 import VectorLayer from "ol/layer/Vector";
-import {Circle, Fill, Stroke, Style, Icon} from "ol/style";
+import {Circle, Fill, Stroke, Style} from "ol/style";
 import proj4 from 'proj4';
 import { register } from 'ol/proj/proj4';
-import {basicMarkerStyle, clickedMarkerStyle, showMarkerStyle} from './MarkerStyle'
+import {basicMarkerStyle, clickedMarkerStyle} from './MarkerStyle'
 
 import Select from 'ol/interaction/Select';
 import { click, pointerMove } from 'ol/events/condition';
-import Overlay from 'ol/Overlay';
 
 import HandleCategoryClick from './HandleCategoryClick';
 import ShowObsOnPath from './ShowObsOnPath';
@@ -157,7 +156,7 @@ const markerClickEventWith = (locaArray, selectClick) => {
     });
 }
 
-export const useMap = () => {
+export const useMap = () => { // 배경지도만 따로 분리
     const [map, setMap] = useState(null);
     //추가부분
     proj4.defs('EPSG:5181', '+proj=tmerc +lat_0=38 +lon_0=127 +k=1 +x_0=200000 +y_0=500000 +ellps=GRS80 +units=m +no_defs');
@@ -291,8 +290,8 @@ export const MapC = ({ pathData, width, height, keyword, setKeyword, bol, bump, 
         }
     }, [map, layerState, pathData, showObs]);
 
-    useEffect(() => {
-        if (map && keyword) {
+    useEffect(() => { // 건물 | 하늘못 | 운동시설 검색 시
+            if (map && keyword) {
             // Replace 'desiredName' with the name you want to filter by
             let cqlFilter = encodeURIComponent("name like '%"+keyword+"%'" + "or nickname like '"+keyword+"' or eng_name ILIKE '%"+keyword+"%'");
 


### PR DESCRIPTION
[뼈대 코드 내용]
- 모든 층 버튼 만들기
    - 층 정보 DB로부터 가져오기 먼저 (server.js 또는 Gerserver에서 WFS로)
    - 층 개수만큼 버튼 생성(for문)
- zoom할 시 층 버튼 가시화
- 각 층 버튼 클릭 시 각 층 실내지도 가시화

*MapC나 App에서 필요 없는 주석이나 코드도 정리