### PR TITLE
fix(PopupC): 길찾기 경로 내 장애물 팝업이 동시에 뜨고 한 종류만 삭제 되던 버그 해결

### DIFF
--- a/src/components/HandleCategoryClick.js
+++ b/src/components/HandleCategoryClick.js
@@ -58,12 +58,11 @@ const HandleCategoryClick = ({category, map}) => {
             return () => {
                 map.removeLayer(layer2Add);
             }
-
         }
     }, [category]);
 
     return (
-        <PopupUIComponent category={category} map={map} layer={showLayer}/>
+        <PopupUIComponent category={category} map={map} layer={[showLayer]}/>
     );
 }
 

--- a/src/components/PopupC.js
+++ b/src/components/PopupC.js
@@ -8,10 +8,10 @@ import { click } from 'ol/events/condition';
 import {showMarkerStyle, clickedLinkStyle} from './MarkerStyle'
 import './MapC.css';
 
-export const setPopupSelect = (layer, map) => {
+const setPopupSelect = (layer, map) => {
     const select = new Select({
         condition: click,
-        layers: [layer],
+        layers: layer,
         hitTolerance: 20
     });
     map.addInteraction(select)
@@ -46,6 +46,25 @@ export const usePopup = (category, map, layer) => {
         map.getOverlays().getArray()[0].setPosition(undefined); // 아이콘 클릭할 때마다 overlay 생성되는데 가장 최근 팝업이 overlay[0]임
         closerRef.current.blur();
     }
+    const setInfoPagePopup = (index) => {
+        setImage(category.data.images[index]);
+        setContent(category.data.info[index]);
+    }
+    const setPathFinderPagePopup = (feature) => {
+        let bumpExist = layer[0].getSource().getFeatures().includes(feature)
+        let bolExist = layer[1].getSource().getFeatures().includes(feature)
+        let linkExist = layer[2].getSource().getFeatures().includes(feature)
+        if (bumpExist) {
+            setImage(feature.get('image_nobs'))
+            setContent('도로턱 높이[cm] <br>'+feature.get('bump_hei'))
+        } else if (bolExist) {
+            setImage(feature.get('image_nobs'))
+            setContent('볼라드 간격[cm] <br>'+feature.get('bol_width'))
+        } else {    // linkExist
+            setImage(feature.get('image_lobs'))
+            setContent('경사도[degree] <br>'+feature.get('slopel'))
+        }
+    }
 
     useEffect(() => {
         // 편의시설 및 장애물 팝업용 overlay 생성
@@ -73,14 +92,12 @@ export const usePopup = (category, map, layer) => {
                 const [ minX, minY, maxX, maxY ] = feature.getGeometry().getExtent();
                 const coordinate = [ (maxX + minX) / 2, (maxY + minY) / 2 ] // 2. 팝업 뜨는 위치를 위한 좌표 설정
                 popupOverlay.setPosition(coordinate); // 3. 팝업 뜨는 위치 설정
+
                 // 4. 팝업 컨텐츠 세팅
-                if(category.type == 'allLinkObs') {
-                    setImage(feature.get('image_lobs'))
-                    setContent(feature.get('slopel'))
+                if(category.type === 'allObs') {
+                    setPathFinderPagePopup(feature);
                 } else {
-                    const index = getIdOf(feature, category)
-                    setImage(category.data.images[index]);
-                    setContent(category.data.info[index]);
+                    setInfoPagePopup(getIdOf(feature, category))
                 }
                 setObstacleNodeID(feature.id_); // node.1574 이런식의 구조.
                 map.addOverlay(popupOverlay) // 5. 팝업 띄우기
@@ -119,7 +136,7 @@ export const PopupUIComponent = ({category, map, layer, onPath, onObstacleAvoida
           <div>{ObstacleNodeID}</div>
           {image && <img src={image} alt="Popup Image" style={{ width: '180px', height: '150px', display: 'block'}}/>}
           <div ref={contentRef} className="ol-popup-content">
-            {(type === 'unpaved' || type === 'stairs' || type === 'slope' || 'allLinkObs') && <>경사도[degree]</>}
+            {(type === 'unpaved' || type === 'stairs' || type === 'slope' || type === 'allLinkObs') && <>경사도[degree]</>}
             {type === 'bump' && <>도로턱 높이[cm]</>}
             {type === 'bol' && <>볼라드 간격[cm]</>}
             <div dangerouslySetInnerHTML={{__html: content}} />

--- a/src/components/ShowObsOnPath.js
+++ b/src/components/ShowObsOnPath.js
@@ -6,13 +6,11 @@ import TileWMS from 'ol/source/TileWMS';
 import VectorSource from "ol/source/Vector";
 import VectorLayer from "ol/layer/Vector";
 import {GeoJSON} from "ol/format";
-import Select from 'ol/interaction/Select';
-import { click } from 'ol/events/condition';
 
 import {makeCrsFilter} from "./utils/crs-filter.js";
 import { Stroke, Style } from "ol/style";
-import {showMarkerStyle, clickedLinkStyle} from './MarkerStyle'
-import {setPopupSelect, PopupUIComponent} from './PopupC'
+import {showMarkerStyle} from './MarkerStyle'
+import {PopupUIComponent} from './PopupC'
 
 const getNodeIdsOnPath = (pathData) => {
     let listOfNodeId = [];
@@ -53,7 +51,7 @@ const createObsLayerWith = (obsType, pathNodeIds) => {
     })
     //console.log(obsSource.getFeatures())
     const obsLayer = new VectorLayer({
-        title: `ShowObsOnPath Layer`,
+        title: `${obsType.type}OnPath Layer`,
         visible: true,
         source: obsSource,
         zIndex: 6,
@@ -87,7 +85,7 @@ const createLayerIfNeeded = (url) => {
                 width: 3
             })
         })
-    });
+    })
 }
 
 const ShowObsOnPath = ({map, pathData, locaArray, bump, bol, showObs, onObstacleAvoidance}) => {
@@ -106,15 +104,13 @@ const ShowObsOnPath = ({map, pathData, locaArray, bump, bol, showObs, onObstacle
                 const bolMarker = createObsLayerWith(bol, pathNodeIds)
                 setBumpLayer(bumpMarker)
                 setBolLayer(bolMarker)
-                map.addLayer(bumpMarker)
-                map.addLayer(bolMarker)
 
                 // 2. 범례 지도에 시각화
                 pathData.forEach((path, index) => {
                     const listOfEdgeId = path.map(e => e.edge);
                     const crsFilter = makeCrsFilter(listOfEdgeId);
                     const legendLayer = new TileLayer({
-                        title: `UOS Shortest Path ${index + 1}`,
+                        title: `legend ${index + 1}`,
                         source: new TileWMS({
                             url: 'http://localhost:8080/geoserver/gp/wms',
                             params: { 'LAYERS': 'gp:link','CQL_FILTER': crsFilter },
@@ -130,6 +126,9 @@ const ShowObsOnPath = ({map, pathData, locaArray, bump, bol, showObs, onObstacle
                 const url = url4AllLinkObs(pathEdgeIds)
                 const linkLayer = createLayerIfNeeded(url)
                 setLinkObsLayer(linkLayer) //setLinkObsLayer(createLayerIfNeeded(url)) 하면 null오류 남
+                //
+                map.addLayer(bumpMarker)
+                map.addLayer(bolMarker)
                 map.addLayer(linkLayer);
 
                 return () => {  // cleanUp
@@ -143,9 +142,7 @@ const ShowObsOnPath = ({map, pathData, locaArray, bump, bol, showObs, onObstacle
 
     return (
         <div>
-            <PopupUIComponent category={bump} map={map} layer={bumpLayer} onPath = {true} onObstacleAvoidance={onObstacleAvoidance}/>
-            <PopupUIComponent category={bol} map={map} layer={bolLayer} onPath = {true} onObstacleAvoidance={onObstacleAvoidance}/>
-            <PopupUIComponent category={{type: 'allLinkObs'}} map={map} layer={linkObsLayer} onPath = {true} onObstacleAvoidance={onObstacleAvoidance}/>
+            {<PopupUIComponent category={{type: 'allObs'}} map={map} layer={[bumpLayer, bolLayer, linkObsLayer]} onPath = {true} onObstacleAvoidance={onObstacleAvoidance}/>}
         </div>
     );
 }


### PR DESCRIPTION
- ShowObsOnPath에서 return할 때 가장 마지막으로 옮겨준 레이어만 맨 위에 떠서 해당 카테고리의 레이어만 삭제만 가능했음(linkObsLayer)
- 그래서 PopupUIComponent를 카테고리 별로 총 세 개를 return하던 방식에서 PopupUIComponent를 한 번만 return하고 대신 layer를 세 개 다 배열로 전달하는 방식으로 변경
- 이에 따라 PopupUIComponent 호출 시 매개변수인 layer를 다 배열로 전달하도록 변경했기 때문에 HandleCategoryClick.js에서 매개변수로 전달하는 layer도 배열로 변경
- 길찾기 페이지 팝업이랑 info 페이지 팝업이랑 구분해서 이미지랑 컨텐츠 설정할 수 있게 함