### PR TITLE
fix(App): 경로 내에 존재하는 link 장애물만 범례 띄우기

### DIFF
--- a/src/components/MapC.js
+++ b/src/components/MapC.js
@@ -280,30 +280,7 @@ export const MapC = ({ pathData, width, height, keyword, setKeyword, bol, bump, 
             if (pathData && pathData.length >= 1) { // 경로를 이루는 간선이 하나라도 존재를 하면
                 createShortestPathLayer(pathData);
                 locaArray = makelocaArrayFromNodes(pathData,locaArray); // pathData 가공해서 locaArray 도출
-
-                // link att를 pathData의 모든 path에서 확인하는 코드
-                pathData.forEach((path, index) => {
-                    path.forEach(item => {
-                        console.log(item.link_att)
-                        if (item.link_att == 5) {
-                            setStairExist(true)
-                        }
-                        if (item.link_att == 4) {
-                            setunpavedExist(true)
-                        }
-                        if (item.link_att != 5 && item.grad_deg>=3.18){
-                            setslopeExist(true)
-                        }
-                        if (item.link_att == 6){
-                            setinExist(true)
-                        }
-
-
-
-                    });
-                });
             }
-
 
             // 출발, 도착, 경유 노드 마커 표시
             if (locaArray && locaArray.length >= 2) {


### PR DESCRIPTION
- MapC.js에 있던 link_att 검사 코드를 삭제 후 App.js의 handleLegendState로 옮김
- usePathFinding() 내에 계단, 비포장, 경사로, 실내 상태를 key로 갖는  legendState를 객체 생성
- usePathFinding() 내에 legendState를 key에 따라 value 설정하는 함수 setExist, 초기화하는 함수 initLegend, link마다 link_att를 검사하고 legendState상태 설정하는 handleLegendState 함수 생성
- App에서 usePathFinding에서 return한 legendState를 받아 각 key들의 value에 따라 범례 이미지 표시
- 다시입력 혹은 길찾기 결과 보기시 이전 결과 범례 초기화