### PR TITLE
fix(ShowObsOnPath): 실내도면 잘 보이도록 레이어 순서 조정

### DIFF
--- a/src/components/ShowObsOnPath.js
+++ b/src/components/ShowObsOnPath.js
@@ -70,7 +70,7 @@ const createObsLayerWith = (obsType, pathNodeIds) => {
         title: `${obsType.type}OnPath Layer`,
         visible: true,
         source: obsSource,
-        zIndex: 6,
+        zIndex: 7,
         style: showMarkerStyle(obsType.type),
     });
     return obsLayer
@@ -97,7 +97,7 @@ const createVisibleLinkObsLayer = (obsType, url) => {
             url: url,
             serverType: 'geoserver'
         }),
-        zIndex: 6,
+        zIndex: 7,
         style:
             new Style({
                 stroke: new Stroke({
@@ -150,7 +150,7 @@ export const ShowObsOnPath = ({map, pathData, locaArray, bump, bol, slopeD, show
                         serverType: 'geoserver',
                         visible: true,
                     }),
-                    zIndex: 2
+                    zIndex: 3
                 });
                 map.addLayer(legendLayer);
             })


### PR DESCRIPTION
- 클릭 객체 7
- locaArray 마커 6
- 출입구 원마커 5
- 건물마커 4
- path별 색 4
- 범례 3
- 실내 2
- 기본지도 1