### PR TITLE
fix(PopupC): info 탭에서 link 장애물 클릭 시 경사도가 0인 건 팝업 내 문구 뜨지 않게 함

### DIFF
--- a/src/components/PopupC.js
+++ b/src/components/PopupC.js
@@ -48,7 +48,14 @@ export const usePopup = (category, map, layer) => {
     }
     const setInfoPagePopup = (index) => {
         setImage(category.data.images[index]);
-        setContent(category.data.info[index]);
+        if (category.type == 'slope' || category.type == 'unpaved' || category.type == 'stairs') {
+            setContent(null)    // 이전에 클릭한 객체 info가 남아있는 경우 방지
+            if (category.data.info[index] > 0) {    //
+                setContent('경사도[degree] <br>'+category.data.info[index]);
+            }
+        } else {
+            setContent(category.data.info[index]);
+        }
     }
     const setPathFinderPagePopup = (feature) => {
         let bumpExist = layer[0].getSource().getFeatures().includes(feature)
@@ -135,7 +142,6 @@ export const PopupUIComponent = ({category, map, layer, onPath, onObstacleAvoida
           <div>{ObstacleID}</div>
           {image && <img src={image} alt="Popup Image" style={{ width: '180px', height: '150px', display: 'block'}}/>}
           <div ref={contentRef} className="ol-popup-content">
-            {(type === 'unpaved' || type === 'stairs' || type === 'slope') && <>경사도[degree]</>}
             {type === 'bump' && <>도로턱 높이[cm]</>}
             {type === 'bol' && <>볼라드 간격[cm]</>}
             <div dangerouslySetInnerHTML={{__html: content}} />


### PR DESCRIPTION
- setInfoPagePopup 함수 내에서 category 타입이 link인 장애물 타입일 경우 경사도가 0인 것은 뜨지 않도록 조건문 추가
- 원래 PopupUIComponent에서만 경사도[degree] 문구를 표시했는데 그럴 경우 0은 안 떠도 경사도 문구가 떠서 애매해짐
- 따라서 경사도 문구까지 일괄로 setInfoPagePopup 함수에서 띄우도록 수정