### PR TITLE
MapC 레이어 조정 / 마커 클릭 이벤트 복구 / 오류 수정

### DIFF
--- a/src/components/MapC.js
+++ b/src/components/MapC.js
@@ -385,7 +385,7 @@ export const MapC = ({ pathData, width, height, keyword, setKeyword, bol, bump, 
     useEffect(() => { // 건물 | 하늘못 | 운동시설 검색 시
         if (map && keyword) {
             // Replace 'desiredName' with the name you want to filter by
-            let cqlFilter = encodeURIComponent("name like '%"+keyword+"%'" + "or nickname like '"+keyword+"' or eng_name ILIKE '%"+keyword+"%'");
+            let cqlFilter = encodeURIComponent("bg_name like '%"+keyword+"%'" + "or nickname like '"+keyword+"' or eng_name ILIKE '%"+keyword+"%'");
             const poiMarkerLayer = createPoiMarkerLayer(cqlFilter)
             map.addLayer(poiMarkerLayer)
 


### PR DESCRIPTION
- chore(MapC): 건물마커 레이어 건물명 텍스트 레이어보다 위로 오도록 zIndex 조정
- style(MapC): 건물 마커 레이어 zIndex 5->6
- feat(MapC): 건물 마커도 클릭 시 반투명화 되는 이벤트 복구
- fix(MapC): 특정 건물 검색 시 마커 2개씩 뜨는 오류 수정