### PR TITLE
fix(MapC): layersState 바뀌어도 검색한 건물 마커 표시 유지되도록 수정

### DIFF
--- a/src/components/MapC.js
+++ b/src/components/MapC.js
@@ -400,7 +400,7 @@ export const MapC = ({ pathData, width, height, keyword, setKeyword, bol, bump, 
                 map.removeLayer(poiMarkerLayer);
            }
         }
-    }, [keyword])
+    }, [layerState,keyword])
 
     return (
         <div>


### PR DESCRIPTION
- 기존 문제: 기본지도에서 배봉관 검색해서 건물 마커가 떴는데 드론지도 클릭하면 초기화되어서 건물 마커가 사라짐
- 기본지도든 드론지도든 현재 지도 상태에 상관없이 검색한 건물 마커가 뜨도록 수정