### PR TITLE
fix(MapC): 건물 이루마커 클릭 후 동일 색으로 투명화되게 변경

### DIFF
--- a/src/components/MapC.js
+++ b/src/components/MapC.js
@@ -130,7 +130,7 @@ const poiMarkerClickEventWith = (keyword, selectClick) => {
 
         selectedFeatures.forEach(function(feature) {
             if (feature.get('bg_name') === keyword) {
-                feature.setStyle(clickedMarkerStyle(irumarker2))
+                feature.setStyle(clickedMarkerStyle(irumarkerE))
                 console.log(keyword + ' click')
             }
         });


### PR DESCRIPTION
- 건물마커는 빨간색인데 클릭하면 기존 초록색이 투명화된 이루마커로 바뀌었음